### PR TITLE
bungcip.better-toml -> tamasfe.even-better-toml

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -64,7 +64,7 @@
         "ms-python.vscode-pylance",
         "VisualStudioExptTeam.vscodeintellicode",
         "exiasr.hadolint",
-        "bungcip.better-toml",
+        "tamasfe.even-better-toml",
         "usernamehw.errorlens",
         "charliermarsh.ruff"
       ]


### PR DESCRIPTION
## 概要

今まで使用していた [better-toml](https://github.com/bungcip/better-toml) がアーカイブされているため、代わりの [even-better-toml](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) を使用する


## 関連

- https://marketplace.visualstudio.com/items?itemName=bungcip.better-toml
- https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml
