### PR TITLE
feat: update python version 3.10 -> 3.11

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.12
+FROM python:3.11.4
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Tokyo

--- a/.github/actions/python_setup/action.yml
+++ b/.github/actions/python_setup/action.yml
@@ -1,7 +1,7 @@
 inputs:
   python-version:
     required: false
-    default: "3.10"
+    default: "3.11"
 runs:
   using: "composite"
   steps:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,6 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "python"
-        versions: [">=3.11.0"]
+        versions: [">=3.12.0"]
     reviewers:
       - "yamap55"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: set up python

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ GitHub のリポジトリページの「Use this template」を押下して使�
 
 ## 環境詳細
 
-- Python : 3.10
+- Python : 3.11
 
 ### 事前準備
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -7,7 +7,7 @@
   "reportUnusedFunction": true,
   "reportUnusedVariable": true,
   "reportDuplicateImport": true,
-  "pythonVersion": "3.10",
+  "pythonVersion": "3.11",
   "pythonPlatform": "Linux",
   "ignore": ["./work"]
 }


### PR DESCRIPTION
## 概要

Python 3.10がリリースされたのが2022-10-24で、1年近くたち、特に問題もなく落ち着いているためバージョンを3.11に変更する

## 詳細

- 割愛
