### PR TITLE
chore: fix lint point

### DIFF
--- a/hoge/huga.py
+++ b/hoge/huga.py
@@ -1,4 +1,5 @@
 """sample"""
+
 from logging import getLogger
 
 logger = getLogger(__name__)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 """main"""
+
 from logging import config
 
 from hoge.huga import Huga


### PR DESCRIPTION
refs. https://github.com/psf/black/releases/tag/23.10.0

> Require one empty line after module-level docstrings.

refs. https://github.com/psf/black/pull/3932
