### PR TITLE
fix: path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,7 +48,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 USER $USERNAME
-ENV PATH "/home/$USERNAME/.poetry/bin:$PATH"
+ENV PATH "$HOME/.local/bin:$PATH"
 
 # poetry install
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true


### PR DESCRIPTION
refs. https://python-poetry.org/docs/#installing-with-the-official-installer

> Add Poetry to your PATH
> The installer creates a poetry wrapper in a well-known, platform-specific directory:
> $HOME/.local/bin on Unix.

![image](https://github.com/yamap55/python_repository_simple/assets/1785817/2d6cffc2-1c8c-4548-ab33-629186c1ced7)
