### PR TITLE
chore: enable chat participant detection in devcontainer settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,7 @@
   "customizations": {
     "vscode": {
       "settings": {
+        "chat.detectParticipant.enabled": true,
         "files.eol": "\n",
         "files.insertFinalNewline": true,
         "files.trimTrailingWhitespace": true,


### PR DESCRIPTION
公式の説明ページは見つからないが、この設定を追加することでGitHub Coplot Chat内で他のファイルを検出したい際には自動的に `@workspace` などを指定してくれるようになる

## 参考

- 実験的なオプション（ `experimental` ）であった時の説明
  - https://zenn.dev/dzeyelid/articles/f26ad0b4dc555d#copilot-chat%E3%81%AB%E3%81%8A%E3%81%91%E3%82%8B%E3%82%A4%E3%83%B3%E3%83%86%E3%83%B3%E3%83%88%E6%A4%9C%E5%87%BA
- Twitterのまとめ
  - https://x.com/yamap_55/status/1874060530769682580
