### PR TITLE
fix: remove unnecessary ruff notification setting from devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,7 +40,6 @@
         "python.analysis.inlayHints.functionReturnTypes": true,
         "python.languageServer": "Pylance",
         "python.analysis.typeCheckingMode": "basic",
-        "ruff.showNotifications": "always",
         // ruff.pathを指定することでVS Code拡張にバンドルされているruffではなくuvのruffを使用する
         "ruff.path": ["/home/vscode/.local/share/uv/tools/ruff/bin/ruff"],
         "vsintellicode.python.completionsEnabled": true,


### PR DESCRIPTION
https://docs.astral.sh/ruff/editors/settings/#shownotifications

> This setting is only used by [ruff-lsp](https://github.com/astral-sh/ruff-lsp) which is deprecated in favor of the native language server. Refer to the [migration guide](https://docs.astral.sh/ruff/editors/migration/) for more information.